### PR TITLE
nix flake init

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+.pre-commit-config.yaml
+.direnv

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### How this works
 
 With Github API:
-get pr merged commit hash ->  compare target branch HEAD ... commit -> get status
+get pr merged commit hash -> compare target branch HEAD ... commit -> get status
 
 nixpkgs-tracker not same as [nixpk.gs/pr-tracker](https://nixpk.gs/pr-tracker.html),
 it does not pass any requests through server to get PR status.
@@ -14,7 +14,6 @@ Therefore, there is no need to worry about any performance issues.
 - [x] Stable link (e.g. https://nixpkgs-tracker.ocfox.me/?pr=331928)
 - [x] Github token for more requests limit (Cookie) (optional)
 - [x] Click `Nixpkgs-Tracker` to switch light / dark
-- [x] Check 5 branches at the same time 
+- [x] Check 5 branches at the same time
 
 <img width="1552" alt="image" src="https://github.com/user-attachments/assets/d247eb27-0320-4384-ad3f-36daca4d0ac0">
-

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,102 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": ["nixpkgs"],
+        "nixpkgs-stable": []
+      },
+      "locked": {
+        "lastModified": 1724440431,
+        "narHash": "sha256-9etXEOUtzeMgqg1u0wp+EdwG7RpmrAZ2yX516bMj2aE=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "c8a54057aae480c56e28ef3e14e4960628ac495b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": ["git-hooks", "nixpkgs"]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724224976,
+        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": ["nixpkgs"]
+      },
+      "locked": {
+        "lastModified": 1724338379,
+        "narHash": "sha256-kKJtaiU5Ou+e/0Qs7SICXF22DLx4V/WhG1P6+k4yeOE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "070f834771efa715f3e74cd8ab93ecc96fabc951",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs-stable.follows = "";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      treefmt-nix,
+      git-hooks,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      treefmtCfg = (treefmt-nix.lib.evalModule pkgs ./treefmt.nix).config.build;
+    in
+    rec {
+      formatter.${system} = treefmtCfg.wrapper;
+      checks.${system} = {
+        formatting = treefmtCfg.check self;
+        git-hooks-check = git-hooks.lib.${system}.run {
+          src = ./.;
+          hooks = {
+            deadnix = {
+              enable = true;
+              stages = [ "pre-push" ];
+            };
+            statix = {
+              enable = true;
+              stages = [ "pre-push" ];
+            };
+            nixfmt = {
+              package = pkgs.nixfmt-rfc-style;
+              enable = true;
+              stages = [
+                "pre-push"
+                "pre-commit"
+              ];
+            };
+          };
+        };
+      };
+      devShells.${system}.default = pkgs.mkShellNoCC {
+        inherit (self.checks.${system}.git-hooks-check) shellHook;
+        buildInputs = self.checks.${system}.git-hooks-check.enabledPackages;
+        packages =
+          [ pkgs.yarn ]
+          ++ [
+            treefmtCfg.wrapper
+            (pkgs.lib.attrValues treefmtCfg.programs)
+          ];
+      };
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+let
+  pkgs = import <nixpkgs> { };
+in
+pkgs.mkShellNoCC { packages = [ pkgs.yarn ]; }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,11 @@ import "./style.css";
 import setupColorScheme from "./scheme.ts";
 import {
   branches,
-  isContain,
+  getMeregeCommit,
   getPR,
   hasToken,
+  isContain,
   setToken,
-  getMeregeCommit,
 } from "./utils.ts";
 
 document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
@@ -135,7 +135,7 @@ async function handlePR(pr: string) {
   async function checkBranch(branch: string) {
     const merged = await isContain(branch, mergeCommit);
     const branchElement = document.querySelector<HTMLHeadingElement>(
-      `#${branch}`
+      `#${branch}`,
     )!;
     if (merged) {
       branchElement.textContent = `${branch} ✅`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,7 @@ type PR = {
 export async function getPR(pr: string): Promise<PR> {
   const response = await fetch(
     `https://api.github.com/repos/nixos/nixpkgs/pulls/${pr}`,
-    { headers }
+    { headers },
   );
 
   const data = await response.json();
@@ -51,7 +51,7 @@ export async function getPR(pr: string): Promise<PR> {
 export async function getMeregeCommit(pr: string): Promise<string> {
   const response = await fetch(
     `https://api.github.com/repos/nixos/nixpkgs/pulls/${pr}`,
-    { headers }
+    { headers },
   );
 
   const data = await response.json();
@@ -61,7 +61,7 @@ export async function getMeregeCommit(pr: string): Promise<string> {
 
 export async function isContain(
   branch: string,
-  commit: string
+  commit: string,
 ): Promise<boolean> {
   const url = `https://api.github.com/repos/nixos/nixpkgs/compare/${branch}...${commit}`;
   const response = await fetch(url, { headers });

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,0 +1,10 @@
+_: {
+  projectRootFile = "flake.nix";
+
+  programs = {
+    nixfmt.enable = true;
+    deadnix.enable = true;
+    statix.enable = true;
+    prettier.enable = true;
+  };
+}


### PR DESCRIPTION
Added a simple flake with basic formatting checks.
`yarn` with a shell.nix is the only thing needed really.

`nix-shell --run "yarn build/dev"`.
or
`nix develop` or `direnv allow` for dev.

Consider this just a suggestion and I don't mind if not accepted, since the build is simple enough to not require nix flakes.