### PR TITLE
fix: crash when there's an error with getting a PR

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,7 +50,7 @@ export async function getPR(pr: string): Promise<PR> {
     status: response.status,
     closed: data.state === "closed" && !data.merged_at,
     merged: data.merged_at !== null,
-    base: data.base.ref,
+    base: data.base?.ref,
   };
 }
 


### PR DESCRIPTION
When the GH API returned an error, it crashed instead of showing it, leaving the user confused.

Before:

![before](https://github.com/user-attachments/assets/74a9d3ca-0ff7-40b3-8719-bc0fedbfcc4a)

After:

![after](https://github.com/user-attachments/assets/018acf59-4065-4d4c-b10a-387f141df029)
